### PR TITLE
chore: fix repo links

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -51,7 +51,7 @@ jobs:
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.repository == 'QuinnWilton/rhizome' && github.ref == 'refs/heads/main' }}
+          auto-push: ${{ github.event_name == 'push' && github.repository == 'fission-codes/rs-rhizome' && github.ref == 'refs/heads/main' }}
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
-  <a href="https://github.com/QuinnWilton/rhizome" target="_blank">
-    <img src="https://raw.githubusercontent.com/QuinnWilton/rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
+  <a href="https://github.com/fission-codes/rs-rhizome" target="_blank">
+    <img src="https://raw.githubusercontent.com/fission-codes/rs-rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
   </a>
 
   <h1 align="center">rhizome</h1>
@@ -12,16 +12,16 @@
     <a href="https://npmjs.com/package/rhizome">
       <img src="https://img.shields.io/npm/v/rhizome" alt="Npm">
     </a>
-    <a href="https://codecov.io/gh/QuinnWilton/rhizome">
-      <img src="https://codecov.io/gh/QuinnWilton/rhizome/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
+    <a href="https://codecov.io/gh/fission-codes/rs-rhizome">
+      <img src="https://codecov.io/gh/fission-codes/rs-rhizome/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/actions?query=">
-      <img src="https://github.com/QuinnWilton/rhizome/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
+    <a href="https://github.com/fission-codes/rs-rhizome/actions?query=">
+      <img src="https://github.com/fission-codes/rs-rhizome/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/blob/main/LICENSE-APACHE">
+    <a href="https://github.com/fission-codes/rs-rhizome/blob/main/LICENSE-APACHE">
       <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License-Apache">
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/blob/main/LICENSE-MIT">
+    <a href="https://github.com/fission-codes/rs-rhizome/blob/main/LICENSE-MIT">
       <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License-MIT">
     </a>
     <a href="https://docs.rs/rhizome">
@@ -39,20 +39,27 @@
 
 ## Outline
 
+- [Outline](#outline)
 - [Crates](#crates)
 - [Usage](#usage)
 - [Testing the Project](#testing-the-project)
 - [Benchmarking the Project](#benchmarking-the-project)
 - [Setting-up rhizome-wasm](#setting-up-rhizome-wasm)
 - [Contributing](#contributing)
+  - [Nix](#nix)
+  - [Formatting](#formatting)
+  - [Pre-commit Hook](#pre-commit-hook)
+  - [Recommended Development Flow](#recommended-development-flow)
+  - [Conventional Commits](#conventional-commits)
 - [Getting Help](#getting-help)
 - [External Resources](#external-resources)
 - [License](#license)
+  - [Contribution](#contribution)
 
 ## Crates
 
-- [rhizome](https://github.com/QuinnWilton/rhizome/tree/main/rhizome)
-- [rhizome-wasm](https://github.com/QuinnWilton/rhizome/tree/main/)
+- [rhizome](https://github.com/fission-codes/rs-rhizome/tree/main/rhizome)
+- [rhizome-wasm](https://github.com/fission-codes/rs-rhizome/tree/main/)
 
 ## Usage
 

--- a/rhizome-wasm/Cargo.toml
+++ b/rhizome-wasm/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2021"
 rust-version = "1.64"
 documentation = "https://docs.rs/rhizome-wasm"
-repository = "https://github.com/QuinnWilton/rhizome/tree/main/rhizome-wasm"
+repository = "https://github.com/fission-codes/rs-rhizome/tree/main/rhizome-wasm"
 authors = ["Quinn Wilton <quinn@quinnwilton.com>"]
 
 [lib]

--- a/rhizome-wasm/README.md
+++ b/rhizome-wasm/README.md
@@ -1,6 +1,6 @@
 <div align="center">
-  <a href="https://github.com/QuinnWilton/rhizome" target="_blank">
-    <img src="https://raw.githubusercontent.com/QuinnWilton/rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
+  <a href="https://github.com/fission-codes/rs-rhizome" target="_blank">
+    <img src="https://raw.githubusercontent.com/fission-codes/rs-rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
   </a>
 
   <h1 align="center">rhizome-wasm</h1>
@@ -12,16 +12,16 @@
     <a href="https://npmjs.com/package/rhizome">
       <img src="https://img.shields.io/npm/v/rhizome" alt="npm">
     </a>
-    <a href="https://codecov.io/gh/QuinnWilton/rhizome">
-      <img src="https://codecov.io/gh/QuinnWilton/rhizome/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
+    <a href="https://codecov.io/gh/fission-codes/rs-rhizome">
+      <img src="https://codecov.io/gh/fission-codes/rs-rhizome/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/actions?query=">
-      <img src="https://github.com/QuinnWilton/rhizome/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
+    <a href="https://github.com/fission-codes/rs-rhizome/actions?query=">
+      <img src="https://github.com/fission-codes/rs-rhizome/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/blob/main/LICENSE-APACHE">
+    <a href="https://github.com/fission-codes/rs-rhizome/blob/main/LICENSE-APACHE">
       <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License-Apache">
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/blob/main/LICENSE-MIT">
+    <a href="https://github.com/fission-codes/rs-rhizome/blob/main/LICENSE-MIT">
       <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License-MIT">
     </a>
     <a href="https://docs.rs/rhizome">
@@ -41,11 +41,13 @@ Description.
 
 ## Outline
 
+- [Outline](#outline)
 - [Set-up](#set-up)
-- [Build for Javascript](#build-for-javascript)
+  - [Build for Javascript](#build-for-javascript)
 - [Testing the Project](#testing-the-project)
 - [Publishing a Package](#publishing-a-package)
 - [License](#license)
+  - [Contribution](#contribution)
 
 ## Set-up
 

--- a/rhizome/Cargo.toml
+++ b/rhizome/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2021"
 rust-version = "1.64"
 documentation = "https://docs.rs/rhizome"
-repository = "https://github.com/QuinnWilton/rhizome/tree/main/rhizome"
+repository = "https://github.com/fission-codes/rs-rhizome/tree/main/rhizome"
 authors = ["Quinn Wilton <quinn@quinnwilton.com>"]
 
 [lib]

--- a/rhizome/README.md
+++ b/rhizome/README.md
@@ -1,6 +1,6 @@
 <div align="center">
-  <a href="https://github.com/QuinnWilton/rhizome" target="_blank">
-    <img src="https://raw.githubusercontent.com/QuinnWilton/rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
+  <a href="https://github.com/fission-codes/rs-rhizome" target="_blank">
+    <img src="https://raw.githubusercontent.com/fission-codes/rs-rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
   </a>
 
   <h1 align="center">rhizome</h1>
@@ -9,16 +9,16 @@
     <a href="https://crates.io/crates/rhizome">
       <img src="https://img.shields.io/crates/v/rhizome?label=crates" alt="Crate">
     </a>
-    <a href="https://codecov.io/gh/QuinnWilton/rhizome">
-      <img src="https://codecov.io/gh/QuinnWilton/rhizome/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
+    <a href="https://codecov.io/gh/fission-codes/rs-rhizome">
+      <img src="https://codecov.io/gh/fission-codes/rs-rhizome/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/actions?query=">
-      <img src="https://github.com/QuinnWilton/rhizome/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
+    <a href="https://github.com/fission-codes/rs-rhizome/actions?query=">
+      <img src="https://github.com/fission-codes/rs-rhizome/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/blob/main/LICENSE-APACHE">
+    <a href="https://github.com/fission-codes/rs-rhizome/blob/main/LICENSE-APACHE">
       <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License-Apache">
     </a>
-    <a href="https://github.com/QuinnWilton/rhizome/blob/main/LICENSE-MIT">
+    <a href="https://github.com/fission-codes/rs-rhizome/blob/main/LICENSE-MIT">
       <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License-MIT">
     </a>
     <a href="https://docs.rs/rhizome">


### PR DESCRIPTION
I may have used the template wrong, and gave my Github username as the codeowner, which led to all of the links being based on my Github profile