### PR TITLE
Fix: point readme to new hosted Fission logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://github.com/fission-codes/rs-rhizome" target="_blank">
-    <img src="https://raw.githubusercontent.com/fission-codes/rs-rhizome/main/assets/a_logo.png" alt="rhizome Logo" width="100"></img>
+    <img src="https://github.com/fission-codes/kit/blob/main/images/logo-icon-coloured.png?raw=true" alt="Fission logo" width="100" />
   </a>
 
   <h1 align="center">rhizome</h1>


### PR DESCRIPTION
# Description

Updating the Fission logo in the readme to reflect our new brand design. (I chose not to update this one yesterday because I thought it was missing a Rhizome logo, but it was actually just the Fission logo link that was broken)

## Link to issue

N/A

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Screenshots/Screencaps

<img width="993" alt="image" src="https://user-images.githubusercontent.com/1179291/214373660-4e4600d1-af67-42b5-a729-f0b475831f64.png">