### PR TITLE
docs: fix some editing mistakes/typos in the contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ of issue that good for those new to the project.
 
 ## Where to Get Help
 
-The main way to get help is on our [discord server](https://fission.codes/discord).server][https://fission.codes/discord].
+The main way to get help is on our [discord server](https://fission.codes/discord).
 Though, this guide should help you get started. It may be slightly lengthy, but it's
 designed for those who are new so please don't let length intimidate you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,7 @@ with others and follow our [code of conduct](./CODE_OF_CONDUCT.md).
 ## How to Contribute
 
 If the code adds a feature that is not already present in an issue, you can
-create a new issue for the feature and add the pull request to it. If the code
-adds a feature that is not already present in an issue, you can create a new
-issue for the feature and add the pull request to it.
+create a new issue for the feature and add the pull request to it.
 
 ### Contributing by Adding a Topic for Discussion
 


### PR DESCRIPTION
# Description

remove what looks like a copy/paste error with an incorrectly formatted markdown link to the discord, and a doubled sentence in the "How to Contribute" section in `CONTRIBUTING.md`

## Link to issue

no issue since "your contribution docs had some typos" felt like it would mostly be noise and there was no doc-specific policy for contribution. however, if you'd like i can open one

## Type of change

- [x] ~~Comments~~ Docs have been added/updated

## Test plan (required)

the github markdown render preview showed both that:
* the link to the discord is not followed by an incorrectly-formatted markdown link (and still works correctly)
* the doubled sentence in the "How to Contribute" section is no longer doubled
