### PR TITLE
Expand wasm bindings

### DIFF
--- a/rhizome-wasm/src/fact.rs
+++ b/rhizome-wasm/src/fact.rs
@@ -23,7 +23,7 @@ impl InputFact {
 #[wasm_bindgen]
 impl InputFact {
     #[wasm_bindgen(constructor)]
-    pub fn new(entity: i64, attribute: &str, value: JsValue, links_obj: &js_sys::Object) -> Self {
+    pub fn new(entity: &str, attribute: &str, value: JsValue, links_obj: &js_sys::Object) -> Self {
         let mut links = Vec::default();
         let keys = js_sys::Reflect::own_keys(links_obj).unwrap();
 
@@ -44,7 +44,7 @@ impl InputFact {
             Self(DefaultEDBFact::new(entity, attribute, val as i64, links).unwrap())
         } else if let Some(val) = value.as_string() {
             Self(DefaultEDBFact::new(entity, attribute, val.as_ref(), links).unwrap())
-        } else if let Ok(val) = serde_wasm_bindgen::from_value::<Cid>(value.clone()) {
+        } else if let Ok(val) = serde_wasm_bindgen::from_value::<Cid>(value) {
             Self(DefaultEDBFact::new(entity, attribute, val.inner(), links).unwrap())
         } else {
             panic!("unknown type")

--- a/rhizome-wasm/tests/web.rs
+++ b/rhizome-wasm/tests/web.rs
@@ -2,6 +2,6 @@
 
 //! Test suite for the Web and headless browsers.
 
-use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use wasm_bindgen_test::{wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);

--- a/rhizome/src/error.rs
+++ b/rhizome/src/error.rs
@@ -41,8 +41,6 @@ pub enum Error {
     TypeMismatch(Type, Type),
     #[error("Type mismatch: expected {0}, got {1}")]
     VarTypeConflict(Var, Type),
-    #[error("Unconstrained var {0}")]
-    UnconstrainedVar(Var),
     #[error("Attempted to bind {2} to {1} of type {3} in {0}")]
     ColumnValueTypeConflict(RelationId, ColId, ColVal, ColType),
     #[error("Facts must be ground: attempted to bind {1} to variable {2} of relation {0}")]

--- a/rhizome/src/lib.rs
+++ b/rhizome/src/lib.rs
@@ -12,7 +12,6 @@ pub(crate) mod lattice;
 pub(crate) mod logic;
 pub(crate) mod ram;
 pub(crate) mod relation;
-pub(crate) mod value;
 
 pub mod error;
 pub mod fact;
@@ -21,6 +20,7 @@ pub mod runtime;
 pub mod storage;
 pub mod timestamp;
 pub mod types;
+pub mod value;
 pub mod var;
 
 pub use logic::{build, ProgramBuilder, RuleVars};

--- a/rhizome/src/logic/ast/body_term.rs
+++ b/rhizome/src/logic/ast/body_term.rs
@@ -9,7 +9,7 @@ use derive_more::{From, IsVariant};
 
 use crate::{
     error::Error,
-    id::{ColId, LinkId},
+    id::{ColId, LinkId, VarId},
     logic::{ReduceClosure, VarClosure},
     value::Val,
     var::Var,
@@ -98,8 +98,10 @@ impl Negation {
         &self.args
     }
 
-    pub fn is_vars_bound<T>(&self, bindings: &im::HashMap<Var, T>) -> bool {
-        self.vars().iter().all(|var| bindings.contains_key(var))
+    pub fn is_vars_bound<T>(&self, bindings: &im::HashMap<VarId, T>) -> bool {
+        self.vars()
+            .iter()
+            .all(|var| bindings.contains_key(&var.id()))
     }
 
     pub fn vars(&self) -> HashSet<&Var> {
@@ -169,8 +171,10 @@ impl VarPredicate {
         Arc::clone(&self.f)
     }
 
-    pub fn is_vars_bound<T>(&self, bindings: &im::HashMap<Var, T>) -> bool {
-        self.vars.iter().all(|var| bindings.contains_key(var))
+    pub fn is_vars_bound<T>(&self, bindings: &im::HashMap<VarId, T>) -> bool {
+        self.vars()
+            .iter()
+            .all(|var| bindings.contains_key(&var.id()))
     }
 }
 
@@ -234,8 +238,10 @@ impl Reduce {
         Arc::clone(&self.f)
     }
 
-    pub fn is_vars_bound<T>(&self, bindings: &im::HashMap<Var, T>) -> bool {
-        self.vars.iter().all(|var| bindings.contains_key(var))
+    pub fn is_vars_bound<T>(&self, bindings: &im::HashMap<VarId, T>) -> bool {
+        self.vars()
+            .iter()
+            .all(|var| bindings.contains_key(&var.id()))
     }
 }
 

--- a/rhizome/src/logic/ast/cid_value.rs
+++ b/rhizome/src/logic/ast/cid_value.rs
@@ -2,7 +2,7 @@ use cid::Cid;
 use derive_more::{IsVariant, TryInto};
 
 use crate::{
-    types::{FromType, Type},
+    types::{ColType, FromType},
     var::{TypedVar, Var},
 };
 
@@ -26,10 +26,15 @@ impl From<&Var> for CidValue {
 
 impl<T> From<&TypedVar<T>> for CidValue
 where
-    Type: FromType<T>,
-    T: Copy,
+    ColType: FromType<T>,
 {
     fn from(value: &TypedVar<T>) -> Self {
-        Self::Var((*value).into())
+        let var = if let ColType::Any = value.typ() {
+            Var::new::<Cid>(value.id().to_string().as_ref())
+        } else {
+            Var::new::<T>(value.id().to_string().as_ref())
+        };
+
+        Self::Var(var)
     }
 }

--- a/rhizome/src/logic/builder.rs
+++ b/rhizome/src/logic/builder.rs
@@ -1577,21 +1577,4 @@ mod tests {
             Ok(p)
         });
     }
-
-    #[test]
-    fn test_any_must_be_known() {
-        assert_compile_err!(&Error::UnconstrainedVar(Var::new::<Any>("x0")), |p| {
-            p.input("in", |h| h.column::<Any>("v"))?;
-            p.output("out", |h| h.column::<Any>("v"))?;
-
-            p.rule::<[Any; 1]>("out", &|h, b, [v]| {
-                h.bind((("v", v),))?;
-                b.search("in", (("v", v),))?;
-
-                Ok(())
-            })?;
-
-            Ok(p)
-        });
-    }
 }

--- a/rhizome/src/logic/builder/program.rs
+++ b/rhizome/src/logic/builder/program.rs
@@ -6,7 +6,6 @@ use crate::{
     id::RelationId,
     logic::ast::{Clause, Declaration, Program, Rule},
     relation::Source,
-    types::ColType,
 };
 
 use super::{
@@ -109,12 +108,6 @@ impl ProgramBuilder {
 
         let body = body_builder.finalize(&mut bound_vars)?;
         let head = head_builder.finalize(&mut bound_vars)?;
-
-        for (var, bound_type) in bound_vars {
-            if bound_type == ColType::Any {
-                return error(Error::UnconstrainedVar(var));
-            }
-        }
 
         match declaration.source() {
             Source::Edb => error(Error::ClauseHeadEDB(declaration.id())),

--- a/rhizome/src/logic/builder/reduce.rs
+++ b/rhizome/src/logic/builder/reduce.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use crate::{
     col_val::ColVal,
     error::{error, Error},
-    id::ColId,
+    id::{ColId, VarId},
     logic::{
         ast::{Declaration, Reduce},
         ReduceClosure,
@@ -35,9 +35,12 @@ impl ReduceBuilder {
     pub(crate) fn finalize(
         self,
         relation: Arc<Declaration>,
-        bound_vars: &mut HashMap<Var, ColType>,
+        bound_vars: &mut HashMap<VarId, ColType>,
     ) -> Result<Reduce> {
-        if bound_vars.insert(self.target, self.target.typ()).is_some() {
+        if bound_vars
+            .insert(self.target.id(), self.target.typ())
+            .is_some()
+        {
             return error(Error::ReduceBoundTarget(self.target.id()));
         }
 
@@ -70,7 +73,7 @@ impl ReduceBuilder {
                         return error(Error::ReduceGroupByTarget(var.id()));
                     }
 
-                    if !bound_vars.contains_key(var) && !self.vars.contains(var) {
+                    if !bound_vars.contains_key(&var.id()) && !self.vars.contains(var) {
                         return error(Error::ReduceUnboundGroupBy(var.id(), col_id, relation.id()));
                     }
 

--- a/rhizome/src/logic/builder/rel_predicate.rs
+++ b/rhizome/src/logic/builder/rel_predicate.rs
@@ -4,10 +4,9 @@ use std::{cell::RefCell, collections::HashMap, sync::Arc};
 use crate::{
     col_val::ColVal,
     error::{error, Error},
-    id::ColId,
+    id::{ColId, VarId},
     logic::ast::{Declaration, RelPredicate},
     types::ColType,
-    var::Var,
 };
 
 use super::atom_args::AtomArg;
@@ -18,15 +17,10 @@ pub struct RelPredicateBuilder {
 }
 
 impl RelPredicateBuilder {
-    pub fn new() -> Self {
-        Self {
-            bindings: RefCell::default(),
-        }
-    }
     pub fn finalize(
         self,
         relation: Arc<Declaration>,
-        bound_vars: &mut HashMap<Var, ColType>,
+        bound_vars: &mut HashMap<VarId, ColType>,
     ) -> Result<RelPredicate> {
         let mut cols = HashMap::default();
 
@@ -54,7 +48,7 @@ impl RelPredicateBuilder {
                 }
                 ColVal::Binding(var) => {
                     if let Ok(unified) = col.col_type().unify(&var.typ()) {
-                        bound_vars.insert(*var, unified);
+                        bound_vars.insert(var.id(), unified);
                     } else {
                         return error(Error::ColumnValueTypeConflict(
                             relation.id(),
@@ -78,9 +72,9 @@ impl RelPredicateBuilder {
     where
         T: AtomArg<A>,
     {
-        let (id, value) = binding.into_col();
+        let (id, val) = binding.into_col();
 
-        self.bindings.borrow_mut().push((id, value));
+        self.bindings.borrow_mut().push((id, val));
 
         Ok(())
     }

--- a/rhizome/src/runtime/reactor.rs
+++ b/rhizome/src/runtime/reactor.rs
@@ -187,7 +187,7 @@ where {
                     .map_err(|_| Error::InternalRhizomeError("client channel closed".to_owned()))?;
             }
             ClientCommand::RegisterSink(id, create_sink, sender) => {
-                let (tx, mut rx) = mpsc::channel(1);
+                let (tx, mut rx) = mpsc::channel(100);
                 let create_task = move || async move {
                     let mut sink = Box::into_pin(create_sink());
 

--- a/rhizome/src/var.rs
+++ b/rhizome/src/var.rs
@@ -74,6 +74,10 @@ where
     pub fn id(&self) -> VarId {
         self.id
     }
+
+    pub fn typ(&self) -> ColType {
+        self.typ
+    }
 }
 
 impl<T> Display for TypedVar<T> {


### PR DESCRIPTION
This exposes more of the query engine to wasm, to support negation, querying content addressed links, and better supporting the dynamic type constraints of calling everything from Javascript.

The wasm bindings are still very rough and difficult to use, but things are increasingly functional.