### PR TITLE
Switch the reactor to use a HashMap

### DIFF
--- a/rhizome/src/id.rs
+++ b/rhizome/src/id.rs
@@ -10,7 +10,7 @@ impl<T, U> Id<T, U> {
     pub fn new<S: AsRef<str>>(id: S) -> Self {
         let symbol = Symbol::get_or_intern(id.as_ref());
 
-        Self(symbol, PhantomData::default())
+        Self(symbol, PhantomData)
     }
 
     pub fn resolve(&self) -> String {

--- a/rhizome/src/ram/operation/project.rs
+++ b/rhizome/src/ram/operation/project.rs
@@ -58,7 +58,7 @@ where
             version,
             cols,
             relation: into,
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 

--- a/rhizome/src/runtime/client.rs
+++ b/rhizome/src/runtime/client.rs
@@ -27,7 +27,7 @@ impl Client {
 
         let client = Self {
             command_tx,
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         };
 
         let reactor = <Reactor>::new(command_rx, event_tx);

--- a/rhizome/src/var.rs
+++ b/rhizome/src/var.rs
@@ -67,7 +67,7 @@ where
         Self {
             id,
             typ,
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 


### PR DESCRIPTION
# Description

This converts the sinks to use a HashMap instead of a list, as described in the below issue. This also removes a few unnecessary clones and changes the formatting on some defaults, just for the hell of it.

## Link to issue

https://github.com/RhizomeDB/rs-rhizome/issues/25

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

I ran `cargo test --workspace` and got all green on my machine. I assume this is sufficient as there should be no observable API changes with this refactoring, just a slight speedup in on certain workloads.
