### PR TITLE
fix: fix tc example not printing any tuples

### DIFF
--- a/rhizome-tokio/examples/tc.rs
+++ b/rhizome-tokio/examples/tc.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use anyhow::Result;
 use futures::{sink::unfold, StreamExt};
 use rhizome::{
@@ -63,16 +61,11 @@ async fn main() -> Result<()> {
         .register_sink(
             "path",
             Box::new(|| {
-                Box::new(unfold(
-                    BTreeSet::default(),
-                    move |mut rel, fact: BTreeFact| async move {
-                        if !rel.insert(fact.clone()) {
-                            println!("{fact}");
-                        }
+                Box::new(unfold((), move |(), fact: BTreeFact| async move {
+                    println!("{fact}");
 
-                        Ok(rel)
-                    },
-                ))
+                    Ok(())
+                }))
             }),
         )
         .await?;


### PR DESCRIPTION
This check was a remnant of an earlier version that would sometimes infer duplicate tuples.