### PR TITLE
Update package exports

### DIFF
--- a/rhizome-wasm/package.json
+++ b/rhizome-wasm/package.json
@@ -17,20 +17,25 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./lib/browser/rhizome_wasm.d.ts",
-      "default": "./lib/browser/rhizome_wasm.js",
-      "deno": {
-        "types": "./lib/deno/rhizome_wasm.d.ts",
-        "default": "./lib/deno/rhizome_wasm.js"
+      "browser": {
+        "types": "./lib/browser/rhizome_wasm.d.ts",
+        "import": "./lib/browser/rhizome_wasm.js"
       },
       "node": {
         "types": "./lib/node/rhizome_wasm.d.ts",
+        "import": "./lib/browser/rhizome_wasm.js",
         "require": "./lib/node/rhizome_wasm.js"
+      },
+      "deno": {
+        "types": "./lib/deno/rhizome_wasm.d.ts",
+        "import": "./lib/deno/rhizome_wasm.js"
       },
       "workerd": {
         "types": "./lib/workerd/rhizome_wasm.d.ts",
-        "default": "./lib/workerd/index.js"
-      }
+        "import": "./lib/workerd/index.js"
+      },
+      "import": "./lib/browser/rhizome_wasm.js",
+      "require": "./lib/node/rhizome_wasm.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Description

This PR implements the following changes:

- [x] Add `browser` entry point to make it explicit and not rely on defaults
- [x] Add an `import` entry point for `node`
- [x] Remove `default` entry point and replace it with `import` and `require` options
- [x] Update `deno` and `workerd` default entry points to `import` (they are ES modules)
 
The `import` entry point for `node` turns out to be necessary in environments like SvelteKit where SSR looks for `node`, but does not support CommonJS. It's not entirely clear that browser package is what we want here, but at least in SvelteKit it will make instantiating the Wasm module consistent for SSR and browser use cases.

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Test it with `betterboxd` to make sure we are still good there.
